### PR TITLE
Fix null error for HomeArticles

### DIFF
--- a/client/src/components/Articles/ArticlesContainer.jsx
+++ b/client/src/components/Articles/ArticlesContainer.jsx
@@ -30,15 +30,13 @@ export const ArticlesContainer = () => {
     let ignore = false;
 
     const fetchArticles = async () => {
+      // `http://localhost:3001/api/articles/${articlesType}/${currentUser.user_id}`
       // `/api/articles/${articlesType}/${currentUser.user_id}`
       try {
         if (!ignore) {
-          const response = await fetch(
-            `http://localhost:3001/api/articles/${articlesType}/${currentUser.user_id}`,
-            {
-              credentials: 'include',
-            }
-          );
+          const response = await fetch(`/api/articles/${articlesType}/${currentUser.user_id}`, {
+            credentials: 'include',
+          });
 
           if (!response.ok) {
             throw new Error('There was a problem retrieving articles.');

--- a/client/src/components/Articles/HomeArticleCard.jsx
+++ b/client/src/components/Articles/HomeArticleCard.jsx
@@ -40,8 +40,8 @@ export const HomeArticleCard = ({ articleData, isOpen, setIsOpen }) => {
 
   const addArticle = useCallback(
     async (type) => {
-      const sessionArticles = JSON.parse(sessionStorage.getItem('articles'));
-      let updatedArticles;
+      // const sessionArticles = JSON.parse(sessionStorage.getItem('articles'));
+      // let updatedArticles;
       const isLoggedIn = checkUser(currentUser, isOpen, setIsOpen);
 
       if (!isLoggedIn) {
@@ -59,14 +59,14 @@ export const HomeArticleCard = ({ articleData, isOpen, setIsOpen }) => {
         const response = await httpAddArticle(favoriteArticleData);
 
         if (response.ok) {
-          updatedArticles = updateSessionStorage(
-            type,
-            sessionArticles,
-            favoriteArticleData.articleTitle,
-            true
-          );
+          // updatedArticles = updateSessionStorage(
+          //   type,
+          //   sessionArticles,
+          //   favoriteArticleData.articleTitle,
+          //   true
+          // );
 
-          sessionStorage.setItem('articles', JSON.stringify(updatedArticles));
+          // sessionStorage.setItem('articles', JSON.stringify(updatedArticles));
 
           return setIsFavorite(true);
         }
@@ -75,14 +75,14 @@ export const HomeArticleCard = ({ articleData, isOpen, setIsOpen }) => {
       const response = await httpAddArticle(readLaterArticleData);
 
       if (response.ok) {
-        updatedArticles = updateSessionStorage(
-          type,
-          sessionArticles,
-          readLaterArticleData.articleTitle,
-          true
-        );
+        // updatedArticles = updateSessionStorage(
+        //   type,
+        //   sessionArticles,
+        //   readLaterArticleData.articleTitle,
+        //   true
+        // );
 
-        sessionStorage.setItem('articles', JSON.stringify(updatedArticles));
+        // sessionStorage.setItem('articles', JSON.stringify(updatedArticles));
 
         return setIsReadLater(true);
       }

--- a/client/src/views/HomeView/HomeView.jsx
+++ b/client/src/views/HomeView/HomeView.jsx
@@ -48,6 +48,7 @@ export const HomeView = () => {
       try {
         if (!ignore) {
           await checkAuth();
+
           const response = await fetch('/api/news/initiate', options);
           if (!response.ok) {
             throw new Error('Error retrieving data');

--- a/server/src/controllers/settings.controller.js
+++ b/server/src/controllers/settings.controller.js
@@ -54,10 +54,6 @@ const httpUpdateEmailRequest = async (req, res, next) => {
 
     const token = signJWT(updateData, process.env.ACCESS_TOKEN_SECRET, 240);
 
-    // const updateEmailUrl = `${req.protocol}://${req.get(
-    //   'host'
-    // )}/api/settings/update-email/${token}`;
-
     const updateEmailUrl = `https://todayinscience.jamessandoval.dev/api/settings/update-email/${token}`;
 
     const updateEmailHtml = `
@@ -105,7 +101,6 @@ const httpUpdateUserEmail = async (req, res, next) => {
       if (err) {
         return next(new AppError('Error : Failed to destroy the session during logout.', err));
       }
-      // 'http://localhost:3000/login'
 
       res.status(204).redirect('https://todayinscience.jamessandoval.dev/login');
     });
@@ -134,9 +129,6 @@ const httpUpdatePasswordRequest = async (req, res, next) => {
 
     const token = signJWT(updateData, process.env.ACCESS_TOKEN_SECRET, 240);
 
-    // const updatePasswordUrl = `${req.protocol}://${req.get(
-    //   'host'
-    // )}/api/settings/update-password/${token}`;
     const updatePasswordUrl = `https://todayinscience.jamessandoval.dev/api/settings/update-password/${token}`;
 
     const updatePasswordHtml = `
@@ -189,7 +181,7 @@ const httpUpdateUserPassword = async (req, res, next) => {
       if (err) {
         return next(new AppError('Error : Failed to destroy the session during logout.', err));
       }
-      // 'http://localhost:3000/login'
+
       res.status(204).redirect('https://todayinscience.jamessandoval.dev/login');
     });
   } catch (e) {


### PR DESCRIPTION
- null error was occuring for articles that were being retrieved from session storage. Removed the step for adding articles to session storage which was being used to reduce api calls. Instead went with just making api calls in order to keep single source of truth for data and avoid having to sync with session storage